### PR TITLE
Made return type of addr() payable

### DIFF
--- a/contracts/ResolverBase.sol
+++ b/contracts/ResolverBase.sol
@@ -14,7 +14,7 @@ contract ResolverBase {
         _;
     }
 
-    function bytesToAddress(bytes memory b) internal pure returns(address a) {
+    function bytesToAddress(bytes memory b) internal pure returns(address payable a) {
         require(b.length == 20);
         assembly {
             a := div(mload(add(b, 32)), exp(256, 12))

--- a/contracts/profiles/AddrResolver.sol
+++ b/contracts/profiles/AddrResolver.sol
@@ -27,7 +27,7 @@ contract AddrResolver is ResolverBase {
      * @param node The ENS node to query.
      * @return The associated address.
      */
-    function addr(bytes32 node) public view returns (address) {
+    function addr(bytes32 node) public view returns (address payable) {
         bytes memory a = addr(node, COIN_TYPE_ETH);
         if(a.length == 0) {
             return address(0);


### PR DESCRIPTION
Shouldn't cause any backward compatibility issues since `address payable` can be implicitly converted to `address`. More info in #19 