### PR TITLE
Sync solc version across all resolver profiles to ^0.5.0

### DIFF
--- a/contracts/profiles/AddrResolver.sol
+++ b/contracts/profiles/AddrResolver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.8;
+pragma solidity ^0.5.0;
 
 import "../ResolverBase.sol";
 


### PR DESCRIPTION
This is required to pull the `resolvers` package into the ETHRegistrarController as a dependency.