### PR TITLE
Add IconResolver into profiles

### DIFF
--- a/contracts/profiles/IconResolver.sol
+++ b/contracts/profiles/IconResolver.sol
@@ -1,0 +1,36 @@
+pragma solidity ^0.5.0;
+
+import "../ResolverBase.sol";
+
+contract IconNameResolver is ResolverBase {
+    bytes4 constant private ICON_INTERFACE_ID = 0xb12a55dd;
+
+    event IconChanged(bytes32 indexed node, bytes icon);
+
+    mapping(bytes32=>bytes) icons;
+
+    /**
+     * Sets the icon associated with an ENS node.
+     * May only be called by the owner of that node in the ENS registry.
+     * @param node The node to update.
+     * @param icon The icon to set.
+     */
+    function setIcon(bytes32 node, bytes calldata icon) external authorised(node) {
+        icons[node] = icon;
+        emit IconChanged(node, icon);
+    }
+
+    /**
+     * Returns the icon associated with an ENS node.
+     * Defined in EIP181.
+     * @param node The ENS node to query.
+     * @return The associated icon.
+     */
+    function icon(bytes32 node) external view returns (bytes memory) {
+        return icons[node];
+    }
+
+    function supportsInterface(bytes4 interfaceID) public pure returns(bool) {
+        return interfaceID == ICON_INTERFACE_ID || super.supportsInterface(interfaceID);
+    }
+}


### PR DESCRIPTION
This PR adds new resolver IconResolver which adds an icon property to the resolver. This Icon is a multihash addressing to the icon directory. For example it could be an IPFS CID. The directory should contain a set of icons from size 32px to 512px.

Similar icon format is a standard for native apps developers. Such icons could be used as site/dapp favicon or PWA icon, company logo, personal avatar or other identity.

## Icon name convention

Grammar:

```EBNF
name
  = "icon_", size, ".png"
  | "icon_", mode, "_", size, ".png"

mode
  = "light" | "dark"

size
  = size-set
  | size-set, "@2"

size-set
  = "32x32" | "64x64" | "128x128" | "256x256" | "512x512"
```

## Example

Common icon:
```
icon_32x32.png
...
icon_512x512.png
```

Light icon example
```
icon_light_32x32@2x.png
...
icon_light_512x512@2x.png
```
