### PR TITLE
Add DNS zonehash functions

### DIFF
--- a/contracts/profiles/DNSResolver.sol
+++ b/contracts/profiles/DNSResolver.sol
@@ -18,10 +18,7 @@ contract DNSResolver is ResolverBase {
     event DNSZoneCleared(bytes32 indexed node);
 
     // DNSZonehashChanged is emitted whenever a given node's zone hash is updated.
-    event DNSZonehashChanged(bytes32 indexed node, bytes zonehash);
-    // DNSZonehashCleared is emitted whenever a given node's zone hash is cleared.
-    // lasthash is the last known zonehash for the node.
-    event DNSZonehashCleared(bytes32 indexed node, bytes lastzonehash);
+    event DNSZonehashChanged(bytes32 indexed node, bytes lastzonehash, bytes zonehash);
 
     // Zone hashes for the domains.
     // node => contenthash
@@ -127,8 +124,9 @@ contract DNSResolver is ResolverBase {
      * @param hash The zonehash to set
      */
     function setZonehash(bytes32 node, bytes calldata hash) external authorised(node) {
+        bytes memory oldhash = zonehashes[node];
         zonehashes[node] = hash;
-        emit DNSZonehashChanged(node, hash);
+        emit DNSZonehashChanged(node, oldhash, hash);
     }
 
     /**
@@ -138,17 +136,6 @@ contract DNSResolver is ResolverBase {
      */
     function zonehash(bytes32 node) external view returns (bytes memory) {
         return zonehashes[node];
-    }
-
-    /**
-     * clearZonehash clears the hash for the zone.
-     * May only be called by the owner of that node in the ENS registry.
-     * @param node The node to clear.
-     */
-    function clearZonehash(bytes32 node) external authorised(node) {
-        bytes memory lastZonehash = zonehashes[node];
-        delete(zonehashes[node]);
-        emit DNSZonehashCleared(node, lastZonehash);
     }
 
     function supportsInterface(bytes4 interfaceID) public pure returns(bool) {

--- a/contracts/profiles/DNSResolver.sol
+++ b/contracts/profiles/DNSResolver.sol
@@ -21,6 +21,8 @@ contract DNSResolver is ResolverBase {
     event DNSZonehashChanged(bytes32 indexed node, bytes lastzonehash, bytes zonehash);
 
     // Zone hashes for the domains.
+    // A zone hash is an EIP-1577 content hash in binary format that should point to a
+    // resource containing a single zonefile.
     // node => contenthash
     mapping(bytes32=>bytes) private zonehashes;
 

--- a/contracts/profiles/DNSResolver.sol
+++ b/contracts/profiles/DNSResolver.sol
@@ -8,6 +8,7 @@ contract DNSResolver is ResolverBase {
     using BytesUtils for bytes;
 
     bytes4 constant private DNS_RECORD_INTERFACE_ID = 0xa8fa5682;
+    bytes4 constant private DNS_ZONE_INTERFACE_ID = 0x5c47637c;
 
     // DNSRecordChanged is emitted whenever a given node/name/resource's RRSET is updated.
     event DNSRecordChanged(bytes32 indexed node, bytes name, uint16 resource, bytes record);
@@ -15,6 +16,16 @@ contract DNSResolver is ResolverBase {
     event DNSRecordDeleted(bytes32 indexed node, bytes name, uint16 resource);
     // DNSZoneCleared is emitted whenever a given node's zone information is cleared.
     event DNSZoneCleared(bytes32 indexed node);
+
+    // DNSZonehashChanged is emitted whenever a given node's zone hash is updated.
+    event DNSZonehashChanged(bytes32 indexed node, bytes zonehash);
+    // DNSZonehashCleared is emitted whenever a given node's zone hash is cleared.
+    // lasthash is the last known zonehash for the node.
+    event DNSZonehashCleared(bytes32 indexed node, bytes lastzonehash);
+
+    // Zone hashes for the domains.
+    // node => contenthash
+    mapping(bytes32=>bytes) private zonehashes;
 
     // Version the mapping for each zone.  This allows users who have lost
     // track of their entries to effectively delete an entire zone by bumping
@@ -109,8 +120,41 @@ contract DNSResolver is ResolverBase {
         emit DNSZoneCleared(node);
     }
 
+    /**
+     * setZonehash sets the hash for the zone.
+     * May only be called by the owner of that node in the ENS registry.
+     * @param node The node to update.
+     * @param hash The zonehash to set
+     */
+    function setZonehash(bytes32 node, bytes calldata hash) external authorised(node) {
+        zonehashes[node] = hash;
+        emit DNSZonehashChanged(node, hash);
+    }
+
+    /**
+     * zonehash obtains the hash for the zone.
+     * @param node The ENS node to query.
+     * @return The associated contenthash.
+     */
+    function zonehash(bytes32 node) external view returns (bytes memory) {
+        return zonehashes[node];
+    }
+
+    /**
+     * clearZonehash clears the hash for the zone.
+     * May only be called by the owner of that node in the ENS registry.
+     * @param node The node to clear.
+     */
+    function clearZonehash(bytes32 node) external authorised(node) {
+        bytes memory lastZonehash = zonehashes[node];
+        delete(zonehashes[node]);
+        emit DNSZonehashCleared(node, lastZonehash);
+    }
+
     function supportsInterface(bytes4 interfaceID) public pure returns(bool) {
-        return interfaceID == DNS_RECORD_INTERFACE_ID || super.supportsInterface(interfaceID);
+        return interfaceID == DNS_RECORD_INTERFACE_ID ||
+               interfaceID == DNS_ZONE_INTERFACE_ID ||
+               super.supportsInterface(interfaceID);
     }
 
     function setDNSRRSet(

--- a/test/TestPublicResolver.js
+++ b/test/TestPublicResolver.js
@@ -584,14 +584,6 @@ contract('PublicResolver', function (accounts) {
             assert.equal(await resolver.zonehash(node), '0x0000000000000000000000000000000000000000000000000000000000000002');
         });
 
-        it('can clear zonehash', async () => {
-            await resolver.setZonehash(node, '0x0000000000000000000000000000000000000000000000000000000000000001', {from: accounts[0]});
-            assert.equal(await resolver.zonehash(node), '0x0000000000000000000000000000000000000000000000000000000000000001');
-
-            await resolver.clearZonehash(node, {from: accounts[0]});
-            assert.equal(await resolver.zonehash(node), null);
-        });
-
         it('forbids setting zonehash by non-owners', async () => {
             try {
                 await resolver.setZonehash(node, '0x0000000000000000000000000000000000000000000000000000000000000001', {from: accounts[1]});
@@ -614,21 +606,34 @@ contract('PublicResolver', function (accounts) {
             assert.fail('setting did not fail');
         });
 
-        it('forbids clearing zonehash by non-owners', async () => {
-            try {
-                await resolver.clearZonehash(node, {from: accounts[1]});
-            } catch (error) {
-                return utils.ensureException(error);
-            }
-
-            assert.fail('clearing did not fail');
-        });
-
         it('returns empty when fetching nonexistent zonehash', async () => {
             assert.equal(
                 await resolver.zonehash(node),
                 null
             );
+        });
+
+        it('emits the correct event', async () => {
+            var tx = await resolver.setZonehash(node, '0x0000000000000000000000000000000000000000000000000000000000000001', {from: accounts[0]});
+            assert.equal(tx.logs.length, 1);
+            assert.equal(tx.logs[0].event, "DNSZonehashChanged");
+            assert.equal(tx.logs[0].args.node, node);
+            assert.equal(tx.logs[0].args.lastzonehash, undefined);
+            assert.equal(tx.logs[0].args.zonehash, '0x0000000000000000000000000000000000000000000000000000000000000001');
+
+            tx = await resolver.setZonehash(node, '0x0000000000000000000000000000000000000000000000000000000000000002', {from: accounts[0]});
+            assert.equal(tx.logs.length, 1);
+            assert.equal(tx.logs[0].event, "DNSZonehashChanged");
+            assert.equal(tx.logs[0].args.node, node);
+            assert.equal(tx.logs[0].args.lastzonehash, '0x0000000000000000000000000000000000000000000000000000000000000001');
+            assert.equal(tx.logs[0].args.zonehash, '0x0000000000000000000000000000000000000000000000000000000000000002');
+
+            tx = await resolver.setZonehash(node, '0x0000000000000000000000000000000000000000000000000000000000000000', {from: accounts[0]});
+            assert.equal(tx.logs.length, 1);
+            assert.equal(tx.logs[0].event, "DNSZonehashChanged");
+            assert.equal(tx.logs[0].args.node, node);
+            assert.equal(tx.logs[0].args.lastzonehash, '0x0000000000000000000000000000000000000000000000000000000000000002');
+            assert.equal(tx.logs[0].args.zonehash, '0x0000000000000000000000000000000000000000000000000000000000000000');
         });
     });
 


### PR DESCRIPTION
This patch adds the ability to get and set DNS zone contenthashes.  The idea of them is the zonehash points to a zonefile that can be used by resolvers, providing a fixed-cost method of updating zones regardless of the size of the file.

One item of interest here is that the update event contains both the old and new contenthashes.  This is to make removal of old zonefiles easier, especially when the new contenthash is 0 (_i.e._ the zonefile is to be removed).