### PR TITLE
Add contract implementation for multiple contenthash records

### DIFF
--- a/contracts/profiles/ContentHashResolver.sol
+++ b/contracts/profiles/ContentHashResolver.sol
@@ -4,32 +4,55 @@ import "../ResolverBase.sol";
 
 contract ContentHashResolver is ResolverBase {
     bytes4 constant private CONTENT_HASH_INTERFACE_ID = 0xbc1c58d1;
+    bytes4 constant private MULTI_CONTENT_HASH_INTERFACE_ID = 0x6de03e07;
 
     event ContenthashChanged(bytes32 indexed node, bytes hash);
 
-    mapping(bytes32=>bytes) hashes;
+    mapping(bytes32=>mapping(bytes=>bytes)) hashes;
 
     /**
-     * Sets the contenthash associated with an ENS node.
+     * Sets the default contenthash associated with an ENS node.
      * May only be called by the owner of that node in the ENS registry.
      * @param node The node to update.
-     * @param hash The contenthash to set
+     * @param hash The contenthash to set.
      */
     function setContenthash(bytes32 node, bytes calldata hash) external authorised(node) {
-        hashes[node] = hash;
+        hashes[node][''] = hash;
         emit ContenthashChanged(node, hash);
     }
 
     /**
-     * Returns the contenthash associated with an ENS node.
+     * Sets the contenthash with specific type associated with an ENS node.
+     * May only be called by the owner of that node in the ENS registry.
+     * @param node The node to update.
+     * @param proto The contenthash protoCode to set.
+     * @param hash The contenthash to set.
+     */
+    function setContenthash(bytes32 node, bytes calldata proto, bytes calldata hash) external authorised(node) {
+        hashes[node][proto] = hash;
+        emit ContenthashChanged(node, hash);
+    }
+
+    /**
+     * Returns the default contenthash associated with an ENS node.
      * @param node The ENS node to query.
      * @return The associated contenthash.
      */
     function contenthash(bytes32 node) external view returns (bytes memory) {
-        return hashes[node];
+        return hashes[node][''];
+    }
+
+    /**
+     * Returns the contenthash with specific type associated with an ENS node.
+     * @param node The ENS node to query.
+     * @param proto The contenthash protoCode to query.
+     * @return The associated contenthash.
+     */
+    function contenthash(bytes32 node, bytes calldata proto) external view returns (bytes memory) {
+        return hashes[node][proto];
     }
 
     function supportsInterface(bytes4 interfaceID) public pure returns(bool) {
-        return interfaceID == CONTENT_HASH_INTERFACE_ID || super.supportsInterface(interfaceID);
+        return interfaceID == CONTENT_HASH_INTERFACE_ID || interfaceID == MULTI_CONTENT_HASH_INTERFACE_ID || super.supportsInterface(interfaceID);
     }
 }

--- a/test/TestPublicResolver.js
+++ b/test/TestPublicResolver.js
@@ -455,23 +455,23 @@ contract('PublicResolver', function (accounts) {
         });
 
         it('can set specific contenthash type', async () => {
-            await resolver.setContenthash(node, '0x0100000000000000000000000000000000000000000000000000000000000001', '0x01', {from: accounts[0]});
-            assert.equal(await resolver.contenthash(node), '0x0100000000000000000000000000000000000000000000000000000000000001', '0x01');
+            await resolver.methods['setContenthash(bytes32,bytes,bytes)'](node, '0x01', '0x0100000000000000000000000000000000000000000000000000000000000001', {from: accounts[0]});
+            assert.equal(await resolver.methods['contenthash(bytes32,bytes)'](node, '0x01')), '0x0100000000000000000000000000000000000000000000000000000000000001';
         });
 
         it('does not overwrite other specific contenthash types', async () => {
-            await resolver.setContenthash(node, '0x0100000000000000000000000000000000000000000000000000000000000001', '0x01', {from: accounts[0]});
-            assert.equal(await resolver.contenthash(node), '0x0100000000000000000000000000000000000000000000000000000000000001', '0x01');
+            await resolver.methods['setContenthash(bytes32,bytes,bytes)'](node, '0x01', '0x0100000000000000000000000000000000000000000000000000000000000001', {from: accounts[0]});
+            assert.equal(await resolver.methods['contenthash(bytes32,bytes)'](node, '0x01'), '0x0100000000000000000000000000000000000000000000000000000000000001');
 
-            await resolver.setContenthash(node, '0x0200000000000000000000000000000000000000000000000000000000000002', '0x02', {from: accounts[0]});
-            assert.equal(await resolver.contenthash(node), '0x0100000000000000000000000000000000000000000000000000000000000001');
+            await resolver.methods['setContenthash(bytes32,bytes,bytes)'](node, '0x02', '0x0200000000000000000000000000000000000000000000000000000000000002', {from: accounts[0]});
+            assert.equal(await resolver.methods['contenthash(bytes32,bytes)'](node, '0x01'), '0x0100000000000000000000000000000000000000000000000000000000000001');
         });
 
         it('does not overwrite default contenthash with specific type', async () => {
             await resolver.setContenthash(node, '0x0000000000000000000000000000000000000000000000000000000000000001', {from: accounts[0]});
             assert.equal(await resolver.contenthash(node), '0x0000000000000000000000000000000000000000000000000000000000000001');
 
-            await resolver.setContenthash(node, '0x0100000000000000000000000000000000000000000000000000000000000001', '0x01', {from: accounts[0]});
+            await resolver.methods['setContenthash(bytes32,bytes,bytes)'](node, '0x01', '0x0100000000000000000000000000000000000000000000000000000000000001', {from: accounts[0]});
             assert.equal(await resolver.contenthash(node), '0x0000000000000000000000000000000000000000000000000000000000000001');
         });
     });

--- a/test/TestPublicResolver.js
+++ b/test/TestPublicResolver.js
@@ -453,6 +453,27 @@ contract('PublicResolver', function (accounts) {
                 null
             );
         });
+
+        it('can set specific contenthash type', async () => {
+            await resolver.setContenthash(node, '0x0100000000000000000000000000000000000000000000000000000000000001', '0x01', {from: accounts[0]});
+            assert.equal(await resolver.contenthash(node), '0x0100000000000000000000000000000000000000000000000000000000000001', '0x01');
+        });
+
+        it('does not overwrite other specific contenthash types', async () => {
+            await resolver.setContenthash(node, '0x0100000000000000000000000000000000000000000000000000000000000001', '0x01', {from: accounts[0]});
+            assert.equal(await resolver.contenthash(node), '0x0100000000000000000000000000000000000000000000000000000000000001', '0x01');
+
+            await resolver.setContenthash(node, '0x0200000000000000000000000000000000000000000000000000000000000002', '0x02', {from: accounts[0]});
+            assert.equal(await resolver.contenthash(node), '0x0100000000000000000000000000000000000000000000000000000000000001');
+        });
+
+        it('does not overwrite default contenthash with specific type', async () => {
+            await resolver.setContenthash(node, '0x0000000000000000000000000000000000000000000000000000000000000001', {from: accounts[0]});
+            assert.equal(await resolver.contenthash(node), '0x0000000000000000000000000000000000000000000000000000000000000001');
+
+            await resolver.setContenthash(node, '0x0100000000000000000000000000000000000000000000000000000000000001', '0x01', {from: accounts[0]});
+            assert.equal(await resolver.contenthash(node), '0x0000000000000000000000000000000000000000000000000000000000000001');
+        });
     });
 
     describe('dns', async () => {

--- a/test/TestPublicResolver.js
+++ b/test/TestPublicResolver.js
@@ -456,7 +456,7 @@ contract('PublicResolver', function (accounts) {
 
         it('can set specific contenthash type', async () => {
             await resolver.methods['setContenthash(bytes32,bytes,bytes)'](node, '0x01', '0x0100000000000000000000000000000000000000000000000000000000000001', {from: accounts[0]});
-            assert.equal(await resolver.methods['contenthash(bytes32,bytes)'](node, '0x01')), '0x0100000000000000000000000000000000000000000000000000000000000001';
+            assert.equal(await resolver.methods['contenthash(bytes32,bytes)'](node, '0x01'), '0x0100000000000000000000000000000000000000000000000000000000000001');
         });
 
         it('does not overwrite other specific contenthash types', async () => {


### PR DESCRIPTION
This PR adds implementation for multiple contenthash records on same ENS domain. It is part of new EIP (that extends the EIP 1577) that I'm writing.

Draft EIP is available in ethereum/EIPs#2520, and discussion should be in ethereum/EIPs#2393.