### PR TITLE
Update StealthKeyResolver to include the prefix for each compressed pub key

### DIFF
--- a/contracts/profiles/StealthKeyResolver.sol
+++ b/contracts/profiles/StealthKeyResolver.sol
@@ -4,36 +4,64 @@ import "../ResolverBase.sol";
 abstract contract StealthKeyResolver is ResolverBase {
     bytes4 constant private STEALTH_KEY_INTERFACE_ID = 0x69a76591;
 
-    event StealthKeyChanged(bytes32 indexed node, uint256 generationPubKey, uint256 encryptionPubKey);
+    event StealthKeyChanged(bytes32 indexed node, uint256 spendingPubKeyPrefix, uint256 spendingPubKey, uint256 viewingPubKeyPrefix, uint256 viewingPubKey);
 
-    struct StealthKey {
-        uint256 generationPubKey;
-        uint256 encryptionPubKey;
-    }
-
-    mapping(bytes32=>StealthKey) _stealthKeys;
+    // node => prefix => key
+    mapping(bytes32 => mapping(uint256 => uint256)) _stealthKeys;
 
     /**
      * Sets the stealth keys associated with an ENS name, for anonymous sends.
      * May only be called by the owner of that node in the ENS registry.
      * @param node The node to update.
-     * @param generationPubKey The public key for generating a stealth address
-     * @param encryptionPubKey The public key to use for encryption
+     * @param spendingPubKeyPrefix Prefix of the spending public key (2 or 3)
+     * @param spendingPubKey The public key for generating a stealth address
+     * @param viewingPubKeyPrefix Prefix of the viewing public key (2 or 3)
+     * @param viewingPubKey The public key to use for encryption
      */
-    function setStealthKeys(bytes32 node, uint256 generationPubKey, uint256 encryptionPubKey) external authorised(node) {
-        _stealthKeys[node] = StealthKey(generationPubKey, encryptionPubKey);
-        emit StealthKeyChanged(node, generationPubKey, encryptionPubKey);
+    function setStealthKeys(bytes32 node, uint256 spendingPubKeyPrefix, uint256 spendingPubKey, uint256 viewingPubKeyPrefix, uint256 viewingPubKey) external authorised(node) {
+        require(
+            (spendingPubKeyPrefix == 2 || spendingPubKeyPrefix == 3) &&
+            (viewingPubKeyPrefix == 2 || viewingPubKeyPrefix == 3),
+            "StealthKeyResolver: Invalid Prefix"
+        );
+
+        delete _stealthKeys[node][0];
+        delete _stealthKeys[node][1];
+        delete _stealthKeys[node][2];
+        delete _stealthKeys[node][3];
+
+        _stealthKeys[node][spendingPubKeyPrefix - 2] = spendingPubKey;
+        _stealthKeys[node][viewingPubKeyPrefix] = viewingPubKey;
+
+        emit StealthKeyChanged(node, spendingPubKeyPrefix, spendingPubKey, viewingPubKeyPrefix, viewingPubKey);
     }
 
     /**
      * Returns the stealth key associated with a name.
      * @param node The ENS node to query.
-     * @return generationPubKey The public key for generating a stealth address.
-     * @return encryptionPubKey The public key to use for encryption.
+     * @return spendingPubKeyPrefix Prefix of the spending public key (2 or 3)
+     * @return spendingPubKey The public key for generating a stealth address
+     * @return viewingPubKeyPrefix Prefix of the viewing public key (2 or 3)
+     * @return viewingPubKey The public key to use for encryption
      */
-    function stealthKeys(bytes32 node) external view returns (uint256 generationPubKey, uint256 encryptionPubKey) {
-        StealthKey memory key = _stealthKeys[node];
-        return (key.generationPubKey, key.encryptionPubKey);
+    function stealthKeys(bytes32 node) external view returns (uint256 spendingPubKeyPrefix, uint256 spendingPubKey, uint256 viewingPubKeyPrefix, uint256 viewingPubKey) {
+        if (_stealthKeys[node][0] != 0) {
+            spendingPubKeyPrefix = 2;
+            spendingPubKey = _stealthKeys[node][0];
+        } else {
+            spendingPubKeyPrefix = 3;
+            spendingPubKey = _stealthKeys[node][1];
+        }
+
+        if (_stealthKeys[node][2] != 0) {
+            viewingPubKeyPrefix = 2;
+            viewingPubKey = _stealthKeys[node][2];
+        } else {
+            viewingPubKeyPrefix = 3;
+            viewingPubKey = _stealthKeys[node][3];
+        }
+
+        return (spendingPubKeyPrefix, spendingPubKey, viewingPubKeyPrefix, viewingPubKey);
     }
 
     function supportsInterface(bytes4 interfaceID) public virtual override pure returns(bool) {

--- a/contracts/profiles/StealthKeyResolver.sol
+++ b/contracts/profiles/StealthKeyResolver.sol
@@ -41,15 +41,18 @@ abstract contract StealthKeyResolver is ResolverBase {
             "StealthKeyResolver: Invalid Prefix"
         );
 
-        delete _stealthKeys[node][0];
-        delete _stealthKeys[node][1];
-        delete _stealthKeys[node][2];
-        delete _stealthKeys[node][3];
-
-        _stealthKeys[node][spendingPubKeyPrefix - 2] = spendingPubKey;
-        _stealthKeys[node][viewingPubKeyPrefix] = viewingPubKey;
-
         emit StealthKeyChanged(node, spendingPubKeyPrefix, spendingPubKey, viewingPubKeyPrefix, viewingPubKey);
+
+        // Shift the spending key prefix down by 2, making it the appropriate index of 0 or 1
+        spendingPubKeyPrefix -= 2;
+
+        // Ensure the opposite prefix indices are empty
+        delete _stealthKeys[node][1 - spendingPubKeyPrefix];
+        delete _stealthKeys[node][5 - viewingPubKeyPrefix];
+
+        // Set the appropriate indices to the new key values
+        _stealthKeys[node][spendingPubKeyPrefix] = spendingPubKey;
+        _stealthKeys[node][viewingPubKeyPrefix] = viewingPubKey;
     }
 
     /**

--- a/contracts/profiles/StealthKeyResolver.sol
+++ b/contracts/profiles/StealthKeyResolver.sol
@@ -4,9 +4,25 @@ import "../ResolverBase.sol";
 abstract contract StealthKeyResolver is ResolverBase {
     bytes4 constant private STEALTH_KEY_INTERFACE_ID = 0x69a76591;
 
+    /// @dev Event emitted when a user updates their resolver stealth keys
     event StealthKeyChanged(bytes32 indexed node, uint256 spendingPubKeyPrefix, uint256 spendingPubKey, uint256 viewingPubKeyPrefix, uint256 viewingPubKey);
 
-    // node => prefix => key
+    /**
+     * @dev Mapping used to store two secp256k1 curve public keys useful for
+     * receiving stealth payments. The mapping records two keys: a viewing
+     * key and a spending key, which can be set and read via the `setsStealthKeys`
+     * and `stealthKey` methods respectively.
+     *
+     * The mapping associates the node to another mapping, which itself maps
+     * the public key prefix to the actual key . This scheme is used to avoid using an
+     * extra storage slot for the public key prefix. For a given node, the mapping
+     * may contain a spending key at position 0 or 1, and a viewing key at position
+     * 2 or 3. See the setter/getter methods for details of how these map to prefixes.
+     *
+     * For more on secp256k1 public keys and prefixes generally, see:
+     * https://github.com/ethereumbook/ethereumbook/blob/develop/04keys-addresses.asciidoc#generating-a-public-key
+     *
+     */
     mapping(bytes32 => mapping(uint256 => uint256)) _stealthKeys;
 
     /**

--- a/test/TestPublicResolver.js
+++ b/test/TestPublicResolver.js
@@ -174,33 +174,46 @@ contract('PublicResolver', function (accounts) {
     });
 
     describe('stealthKeys', async () => {
+        const SPENDING_KEY = 10;
+        const VIEWING_KEY = 20;
+
         it('permits setting stealth keys by owner', async () => {
-            await resolver.setStealthKeys(node, 1, 2, {from: accounts[0]});
+            await resolver.setStealthKeys(node, 2, SPENDING_KEY, 2, VIEWING_KEY, {from: accounts[0]});
             const keys = await resolver.stealthKeys(node)
-            assert.equal(keys[0].toNumber(), 1);
-            assert.equal(keys[1].toNumber(), 2);
+            assert.equal(keys[0].toNumber(), 2);
+            assert.equal(keys[1].toNumber(), SPENDING_KEY);
+            assert.equal(keys[2].toNumber(), 2);
+            assert.equal(keys[3].toNumber(), VIEWING_KEY);
         });
 
         it('can overwrite previously set keys', async () => {
-            await resolver.setStealthKeys(node, 3, 4, {from: accounts[0]});
-            const keys = await resolver.stealthKeys(node)
+            await resolver.setStealthKeys(node, 3, SPENDING_KEY, 2, VIEWING_KEY, {from: accounts[0]});
+            let keys = await resolver.stealthKeys(node)
             assert.equal(keys[0].toNumber(), 3);
-            assert.equal(keys[1].toNumber(), 4);
+            assert.equal(keys[1].toNumber(), SPENDING_KEY);
+            assert.equal(keys[2].toNumber(), 2);
+            assert.equal(keys[3].toNumber(), VIEWING_KEY);
 
-            await resolver.setStealthKeys(node, 5, 6, {from: accounts[0]});
-            const keys2 = await resolver.stealthKeys(node)
-            assert.equal(keys2[0].toNumber(), 5);
-            assert.equal(keys2[1].toNumber(), 6);
+            await resolver.setStealthKeys(node, 2, SPENDING_KEY + 1, 3, VIEWING_KEY + 1, {from: accounts[0]});
+            keys = await resolver.stealthKeys(node)
+            assert.equal(keys[0].toNumber(), 2);
+            assert.equal(keys[1].toNumber(), SPENDING_KEY + 1);
+            assert.equal(keys[2].toNumber(), 3);
+            assert.equal(keys[3].toNumber(), VIEWING_KEY + 1);
         });
 
         it('forbids setting keys by non-owners', async () => {
-            await exceptions.expectFailure(resolver.setStealthKeys(node, 1, 2, {from: accounts[1]}));
+            await exceptions.expectFailure(
+                resolver.setStealthKeys(node, 2, SPENDING_KEY, 2, VIEWING_KEY, {from: accounts[1]})
+            );
         });
 
         it('returns 0 when fetching nonexistent keys', async () => {
             const keys = await resolver.stealthKeys(node)
-            assert.equal(keys[0].toNumber(), 0);
+            assert.equal(keys[0].toNumber(), 3);
             assert.equal(keys[1].toNumber(), 0);
+            assert.equal(keys[2].toNumber(), 3);
+            assert.equal(keys[3].toNumber(), 0);
         });
     });
 


### PR DESCRIPTION
* Rename keys to better reflect what the keys *do*, especially if revealed to a third party
* Add mapping to "store" prefix without using a storage slot
* Add prefix parameters to `setStealthKeys` method
* Return prefixes in `stealthKeys` view method
* Update event emission
* Update test suite